### PR TITLE
fix evaluate() of ContrastiveDataset

### DIFF
--- a/openselfsup/datasets/contrastive.py
+++ b/openselfsup/datasets/contrastive.py
@@ -24,5 +24,5 @@ class ContrastiveDataset(BaseDataset):
         img_cat = torch.cat((img1.unsqueeze(0), img2.unsqueeze(0)), dim=0)
         return dict(img=img_cat)
 
-    def evaluate(self, scores, keyword, logger=None):
+    def evaluate(self, scores, keyword, logger=None, **kwargs):
         raise NotImplemented


### PR DESCRIPTION
Signature of method 'ContrastiveDataset.evaluate()' does not match signature of base method in class 'BaseDataset'