### PR TITLE
Make CIFAR datasets avaliable for ContrastiveDataset

### DIFF
--- a/openselfsup/datasets/contrastive.py
+++ b/openselfsup/datasets/contrastive.py
@@ -12,6 +12,7 @@ class ContrastiveDataset(BaseDataset):
     """
 
     def __init__(self, data_source, pipeline, prefetch=False):
+        data_source['has_labels'] = False
         super(ContrastiveDataset, self).__init__(data_source, pipeline, prefetch)
 
     def __getitem__(self, idx):

--- a/openselfsup/datasets/data_sources/cifar.py
+++ b/openselfsup/datasets/data_sources/cifar.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta, abstractmethod
 from PIL import Image
 
 from torchvision.datasets import CIFAR10, CIFAR100
@@ -5,51 +6,67 @@ from torchvision.datasets import CIFAR10, CIFAR100
 from ..registry import DATASOURCES
 
 
-@DATASOURCES.register_module
-class Cifar10(object):
+class Cifar(metaclass=ABCMeta):
 
-    CLASSES = [
-        'airplane', 'automobile', 'bird', 'cat', 'deer', 'dog', 'frog',
-        'horse', 'ship', 'truck'
-    ]
+    CLASSES = None
 
-    def __init__(self, root, split):
+    def __init__(self, root, split, has_labels=True):
         assert split in ['train', 'test']
-        try:
-            self.cifar = CIFAR10(
-                root=root, train=split == 'train', download=False)
-        except:
-            raise Exception("Please download CIFAR10 manually, \
-                  in case of downloading the dataset parallelly \
-                  that may corrupt the dataset.")
+        self.root = root
+        self.split = split
+        self.has_labels = has_labels
+        self.cifar = None
+        self.set_cifar()
         self.labels = self.cifar.targets
+
+    @abstractmethod
+    def set_cifar(self):
+        pass
 
     def get_length(self):
         return len(self.cifar)
 
     def get_sample(self, idx):
         img = Image.fromarray(self.cifar.data[idx])
-        target = self.labels[idx]  # img: HWC, RGB
-        return img, target
+        if self.has_labels:
+            target = self.labels[idx]  # img: HWC, RGB
+            return img, target
+        else:
+            return img
 
 
 @DATASOURCES.register_module
-class Cifar100(object):
+class Cifar10(Cifar):
 
-    CLASSES = None
+    CLASSES = [
+        'airplane', 'automobile', 'bird', 'cat', 'deer', 'dog', 'frog',
+        'horse', 'ship', 'truck'
+    ]
 
-    def __init__(self, root, split):
-        assert split in ['train', 'test']
+    def __init__(self, root, split, has_labels=True):
+        super().__init__(root, split, has_labels)
+
+    def set_cifar(self):
         try:
-            self.cifar = CIFAR100(
-                root=root, train=split == 'train', download=False)
+            self.cifar = CIFAR10(
+                root=self.root, train=self.split == 'train', download=False)
         except:
             raise Exception("Please download CIFAR10 manually, \
                   in case of downloading the dataset parallelly \
                   that may corrupt the dataset.")
-        self.labels = self.cifar.targets
 
-    def get_sample(self, idx):
-        img = Image.fromarray(self.cifar.data[idx])
-        target = self.labels[idx]  # img: HWC, RGB
-        return img, target
+
+@DATASOURCES.register_module
+class Cifar100(Cifar):
+
+    def __init__(self, root, split, has_labels=True):
+        super().__init__(root, split, has_labels)
+
+    def set_cifar(self):
+        try:
+            self.cifar = CIFAR100(
+                root=self.root, train=self.split == 'train', download=False)
+        except:
+            raise Exception("Please download CIFAR10 manually, \
+                  in case of downloading the dataset parallelly \
+                  that may corrupt the dataset.")


### PR DESCRIPTION
We may use Cifar10 to debug as SimSiam(http://arxiv.org/abs/2011.10566) do, but `ContrastiveDataset` only accept one image as output from `data_source.get_sample()`, so we add `has_labels` to Cifar to satisfy this request.