### PR TITLE
fix: log normally since pytorch1.8

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -4,6 +4,7 @@ import importlib
 import os
 import os.path as osp
 import time
+import logging
 
 import mmcv
 import torch
@@ -87,6 +88,10 @@ def main():
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))
+    # reload `logging` module since pytorch1.8 will init it first
+    # which will get `getLogger` out of control
+    # ref: https://stackoverflow.com/a/53553516
+    importlib.reload(logging)
     # init the logger before other steps
     timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())
     log_file = osp.join(cfg.work_dir, 'train_{}.log'.format(timestamp))


### PR DESCRIPTION
This project can print and save log normally in my old machine with pytorch1.6. When I tried to deploy to new machine with pytorch1.8, I found that the project lost all logs in experiments in both terminal and file system.

After debugging, I found [API in mmcv](https://github.com/MUST-AI-Lab/OpenSelfSup/blob/9206cddefabddbaf1510d88ade7f53dfd910423e/tools/train.py#L87) depends on [pytorch.distributed](https://github.com/pytorch/pytorch/blob/37c1f4a7fef115d719104e871d0cf39434aa9d56/torch/distributed/distributed_c10d.py#L187-L208), and pytorch will initialize logging first which raises my problem.

Then I found a [solution](https://stackoverflow.com/a/53553516) which reloads `logging` module to reslove my problem.