### PR TITLE
[Fix] fix bug when loading cifar dataset

### DIFF
--- a/mmselfsup/datasets/data_sources/base.py
+++ b/mmselfsup/datasets/data_sources/base.py
@@ -83,14 +83,18 @@ class BaseDataSource(object, metaclass=ABCMeta):
         if self.file_client is None:
             self.file_client = mmcv.FileClient(**self.file_client_args)
 
-        if self.data_infos[idx]['img_prefix'] is not None:
-            filename = osp.join(self.data_infos[idx]['img_prefix'],
-                                self.data_infos[idx]['img_info']['filename'])
+        if self.data_infos[idx].get('img_prefix', None) is not None:
+            if self.data_infos[idx]['img_prefix'] is not None:
+                filename = osp.join(
+                    self.data_infos[idx]['img_prefix'],
+                    self.data_infos[idx]['img_info']['filename'])
+            else:
+                filename = self.data_infos[idx]['img_info']['filename']
+            img_bytes = self.file_client.get(filename)
+            img = mmcv.imfrombytes(img_bytes, flag=self.color_type)
         else:
-            filename = self.data_infos[idx]['img_info']['filename']
+            img = self.data_infos[idx]['img']
 
-        img_bytes = self.file_client.get(filename)
-        img = mmcv.imfrombytes(img_bytes, flag=self.color_type)
         img = img.astype(np.uint8)
         return Image.fromarray(img)
 


### PR DESCRIPTION
## Motivation

Error when running linear evaluation on CIFAR with pre-trained models, cifar images are not loaded.

## Modification

Modify the code of `mmselfsup/datasets/data_sources/cifar.py`, it is no need to load again and the key for cifar image is 'img'.

## Use cases (Optional)

Please refer to this [issue](https://github.com/open-mmlab/mmselfsup/issues/186)

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
