### PR TITLE
[Fix] Fix the bug when using prefetch under multi-view methods, e.g., DenseCL

### DIFF
--- a/mmselfsup/datasets/utils.py
+++ b/mmselfsup/datasets/utils.py
@@ -178,9 +178,15 @@ class PrefetchLoader:
 
         for next_input_dict in self.loader:
             with torch.cuda.stream(stream):
-                data = next_input_dict['img'].cuda(non_blocking=True)
-                next_input_dict['img'] = data.float().sub_(self.mean).div_(
-                    self.std)
+                if isinstance(next_input_dict['img'], list):
+                    next_input_dict['img'] = [
+                        data.cuda(non_blocking=True).float().sub_(
+                        self.mean).div_(self.std)
+                        for data in next_input_dict['img']]
+                else:
+                    data = next_input_dict['img'].cuda(non_blocking=True)
+                    next_input_dict['img'] = data.float().sub_(
+                        self.mean).div_(self.std)
 
             if not first:
                 yield input_dict  # noqa F821

--- a/mmselfsup/datasets/utils.py
+++ b/mmselfsup/datasets/utils.py
@@ -181,12 +181,13 @@ class PrefetchLoader:
                 if isinstance(next_input_dict['img'], list):
                     next_input_dict['img'] = [
                         data.cuda(non_blocking=True).float().sub_(
-                        self.mean).div_(self.std)
-                        for data in next_input_dict['img']]
+                            self.mean).div_(self.std)
+                        for data in next_input_dict['img']
+                    ]
                 else:
                     data = next_input_dict['img'].cuda(non_blocking=True)
-                    next_input_dict['img'] = data.float().sub_(
-                        self.mean).div_(self.std)
+                    next_input_dict['img'] = data.float().sub_(self.mean).div_(
+                        self.std)
 
             if not first:
                 yield input_dict  # noqa F821


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. When training large dataset like ImageNet-21k, the memory leak issue usually exists.
2. When using prefetch loader, an error would occur due to [this line](https://github.com/open-mmlab/mmselfsup/blob/7d70d96602949cbac04f29ae91f661a3987b5de9/mmselfsup/datasets/utils.py#L181) ignore the multi-view situation

## Modification

1. Add a new DataSource to mitigate the memory leak following [mmcls](https://github.com/open-mmlab/mmclassification/pull/461)
2. Fix the bug when using prefetch under multi-view methods, e.g., DenseCL

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
