### PR TITLE
[Fix] fix 'no init_cfg' error for pre-trained model backbones when extract features for svm

### DIFF
--- a/tools/benchmarks/classification/svm_voc07/extract.py
+++ b/tools/benchmarks/classification/svm_voc07/extract.py
@@ -122,10 +122,12 @@ def main():
     model.init_weights()
 
     # model is determined in this priority: init_cfg > checkpoint > random
-    if getattr(cfg.model.backbone.init_cfg, 'type', None) == 'Pretrained':
-        logger.info(
-            f'Use pretrained model: '
-            f'{cfg.model.backbone.init_cfg.checkpoint} to extract features')
+    if hasattr(cfg.model.backbone, 'init_cfg'):
+        if getattr(cfg.model.backbone.init_cfg, 'type', None) == 'Pretrained':
+            logger.info(
+                f'Use pretrained model: '
+                f'{cfg.model.backbone.init_cfg.checkpoint} to extract features'
+            )
     elif args.checkpoint is not None:
         logger.info(f'Use checkpoint: {args.checkpoint} to extract features')
         load_checkpoint(model, args.checkpoint, map_location='cpu')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

To fix 'no init_cfg' error for pre-trained model backbones when extract features for svm

## Modification

modify extract.py file in svm_voc07 folder, to check whether the `model`  has `init_cfg` or not.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
