### PR TITLE
[Feature] Add extra dataloader settings in configs.

### DIFF
--- a/mmselfsup/apis/train.py
+++ b/mmselfsup/apis/train.py
@@ -174,11 +174,13 @@ def train_model(model,
     if cfg.get('evaluation', None):
         val_samples_per_gpu = cfg.data.val.pop('samples_per_gpu',
                                                cfg.data.samples_per_gpu)
+        val_workers_per_gpu = cfg.data.val.pop('samples_per_gpu',
+                                               cfg.data.workers_per_gpu)
         val_dataset = build_dataset(cfg.data.val)
         val_dataloader = build_dataloader(
             val_dataset,
             samples_per_gpu=val_samples_per_gpu,
-            workers_per_gpu=cfg.data.workers_per_gpu,
+            workers_per_gpu=val_workers_per_gpu,
             dist=distributed,
             shuffle=False,
             prefetch=cfg.data.val.prefetch,

--- a/mmselfsup/apis/train.py
+++ b/mmselfsup/apis/train.py
@@ -172,7 +172,8 @@ def train_model(model,
 
     # register evaluation hook
     if cfg.get('evaluation', None):
-        val_samples_per_gpu = cfg.data.val.pop('samples_per_gpu', 1)
+        val_samples_per_gpu = cfg.data.val.pop('samples_per_gpu',
+                                               cfg.data.samples_per_gpu)
         val_dataset = build_dataset(cfg.data.val)
         val_dataloader = build_dataloader(
             val_dataset,

--- a/mmselfsup/apis/train.py
+++ b/mmselfsup/apis/train.py
@@ -172,15 +172,15 @@ def train_model(model,
 
     # register evaluation hook
     if cfg.get('evaluation', None):
+        val_samples_per_gpu = cfg.data.val.pop('samples_per_gpu', 1)
         val_dataset = build_dataset(cfg.data.val)
         val_dataloader = build_dataloader(
             val_dataset,
-            samples_per_gpu=cfg.data.samples_per_gpu,
+            samples_per_gpu=val_samples_per_gpu,
             workers_per_gpu=cfg.data.workers_per_gpu,
             dist=distributed,
             shuffle=False,
             prefetch=cfg.data.val.prefetch,
-            drop_last=getattr(cfg.data, 'drop_last', False),
             img_norm_cfg=cfg.get('img_norm_cfg', dict()))
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'

--- a/tests/test_apis/test_train.py
+++ b/tests/test_apis/test_train.py
@@ -53,6 +53,9 @@ def test_train_model():
         cfg.data.samples_per_gpu = 1
         cfg.data.workers_per_gpu = 2
 
+        cfg.data.val.data_source.data_prefix = 'tests/data/'
+        cfg.data.val.data_source.ann_file = 'tests/data/data_list.txt'
+
         # Specify the optimizer
         cfg.optimizer = dict(
             type='SGD', lr=0.005, momentum=0.9, weight_decay=0.0001)
@@ -82,6 +85,9 @@ def test_train_model():
 
         # Build the dataset
         datasets = [ExampleDataset()]
+
+        # evaluation
+        cfg.evaluation = dict(interval=10, topk=(1, 5))
 
         # Start pre-train
         train_model(

--- a/tools/test.py
+++ b/tools/test.py
@@ -114,10 +114,15 @@ def main():
                 'Automatically set "samples_per_gpu"="imgs_per_gpu"='
                 f'{cfg.data.imgs_per_gpu} in this experiments')
         cfg.data.samples_per_gpu = cfg.data.imgs_per_gpu
+
+    samples_per_gpu = cfg.data.val.pop('samples_per_gpu',
+                                       cfg.data.samples_per_gpu)
+    workers_per_gpu = cfg.data.val.pop('samples_per_gpu',
+                                       cfg.data.workers_per_gpu)
     data_loader = build_dataloader(
         dataset,
-        samples_per_gpu=cfg.data.samples_per_gpu,
-        workers_per_gpu=cfg.data.workers_per_gpu,
+        samples_per_gpu=samples_per_gpu,
+        workers_per_gpu=workers_per_gpu,
         dist=distributed,
         shuffle=False)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support to dataloader settings independently in config
Refer to https://github.com/open-mmlab/mmclassification/pull/752

## Modification

Use train_dataloader, val_dataloader and test_dataloader settings in the data field to specify different arguments.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

```python
data = dict(
    samples_per_gpu=32,
    workers_per_gpu=4,
    train=dict(type='xxx', ...),
    val=dict(type='xxx', ...),
    test=dict(type='xxx', ...),
    # Use different batch size during inference.
    val_dataloader=dict(samples_per_gpu=8, workers_per_gpu=2),
)
```

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
