### PR TITLE
[Fix] fix key error bug when registering custom hooks

### DIFF
--- a/mmselfsup/apis/train.py
+++ b/mmselfsup/apis/train.py
@@ -173,7 +173,7 @@ def train_model(model,
             if hook_cfg.type == 'DeepClusterHook':
                 common_params = dict(dist_mode=True, data_loaders=data_loaders)
             else:
-                common_params = dict(dist_mode=True)
+                common_params = dict()
             hook_cfg = hook_cfg.copy()
             priority = hook_cfg.pop('priority', 'NORMAL')
             hook = build_from_cfg(hook_cfg, HOOKS, common_params)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

As the `dist_mode` is an argument of `DeepClusterHook`, it raises TypeError when `runner` registers the other custom hooks, such as EMAHook in mmcv.

## Modification

Remove `dist_mode`  when the custom hook is not `DeepClusterHook`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
