### PR TITLE
[Docs] Configure Myst-parser to parse anchor tag

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -92,5 +92,6 @@ html_css_files = ['css/readthedocs.css']
 
 # Enable ::: for my_st
 myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 4
 
 master_doc = 'index'

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -92,5 +92,6 @@ html_css_files = ['css/readthedocs.css']
 
 # Enable ::: for my_st
 myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 4
 
 master_doc = 'index'


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

By default, myst-parser did not parse links to anchor tags in markdown files, making these hyperlinks become raw texts in docs. This PR updates myst's configuration to enable this feature.
Refer to https://github.com/open-mmlab/mmocr/pull/1012

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
