### PR TITLE
[Fix] update lr_updater.py links

### DIFF
--- a/docs/en/tutorials/4_schedule.md
+++ b/docs/en/tutorials/4_schedule.md
@@ -48,7 +48,7 @@ lr_config = dict(
     ...)
 ```
 
-Then during training, the program will call [CosineAnealingLrUpdaterHook](https://github.com/open-mmlab/mmcv/blob/0092699fef27a0e6cbe9c37f4c4de2fb6996a1c7/mmcv/runner/hooks/lr_updater.py#L269) periodically to update the learning rate.
+Then during training, the program will call [CosineAnnealingLrUpdaterHook](https://github.com/open-mmlab/mmcv/blob/0092699fef27a0e6cbe9c37f4c4de2fb6996a1c7/mmcv/runner/hooks/lr_updater.py#L269) periodically to update the learning rate.
 
 We also support many other learning rate schedules [here](https://github.com/open-mmlab/mmcv/blob/master/mmcv/runner/hooks/lr_updater.py), such as Poly schedule.
 
@@ -94,7 +94,7 @@ lr_config = dict(
 
 We support the momentum scheduler to modify the model's momentum according to learning rate, which could make the model converge in a faster way.
 
-Momentum scheduler is usually used with LR scheduler, for example, the following config is used to accelerate convergence. For more details, please refer to the implementation of [CyclicLrUpdater](https://github.com/open-mmlab/mmcv/blob/f48241a65aebfe07db122e9db320c31b685dc674/mmcv/runner/hooks/lr_updater.py#L327) and [CyclicMomentumUpdater](https://github.com/open-mmlab/mmcv/blob/f48241a65aebfe07db122e9db320c31b685dc674/mmcv/runner/hooks/momentum_updater.py#L130).
+Momentum scheduler is usually used with LR scheduler, for example, the following config is used to accelerate convergence. For more details, please refer to the implementation of [CyclicLrUpdaterHook](https://github.com/open-mmlab/mmcv/blob/0092699fef27a0e6cbe9c37f4c4de2fb6996a1c7/mmcv/runner/hooks/lr_updater.py#L434) and [CyclicMomentumUpdaterHook](https://github.com/open-mmlab/mmcv/blob/0092699fef27a0e6cbe9c37f4c4de2fb6996a1c7/mmcv/runner/hooks/momentum_updater.py#L291).
 
 Here is an example:
 

--- a/docs/en/tutorials/4_schedule.md
+++ b/docs/en/tutorials/4_schedule.md
@@ -48,9 +48,9 @@ lr_config = dict(
     ...)
 ```
 
-Then during training, the program will call [CosineAnealingLrUpdaterHook](https://github.com/open-mmlab/mmcv/blob/f48241a65aebfe07db122e9db320c31b685dc674/mmcv/runner/hooks/lr_updater.py#L227) periodically to update the learning rate.
+Then during training, the program will call [CosineAnealingLrUpdaterHook](https://github.com/open-mmlab/mmcv/blob/0092699fef27a0e6cbe9c37f4c4de2fb6996a1c7/mmcv/runner/hooks/lr_updater.py#L269) periodically to update the learning rate.
 
-We also support many other learning rate schedules [here](https://github.com/open-mmlab/mmcv/blob/f48241a65aebfe07db122e9db320c31b685dc674/mmcv/runner/hooks/lr_updater.py), such as Poly schedule.
+We also support many other learning rate schedules [here](https://github.com/open-mmlab/mmcv/blob/master/mmcv/runner/hooks/lr_updater.py), such as Poly schedule.
 
 ### Warmup strategy
 


### PR DESCRIPTION
replace out-of-date links with master branch links, resolve #351 

## Motivation

Original document's lr_updater.py [link](https://github.com/open-mmlab/mmcv/blob/f48241a65aebfe07db122e9db320c31b685dc674/mmcv/runner/hooks/lr_updater.py#L227) and CosineAnnealingLrUpdaterHook directs to a deprecated version (whose name was still Cosine**An**ealing with only one "n")

## Modification

I update the lr_updater.py link to the [master branch](https://github.com/open-mmlab/mmcv/blob/master/mmcv/runner/hooks/lr_updater.py), and the CosineAnnealingLrUpdaterHook() link to [current version's](https://github.com/open-mmlab/mmcv/blob/0092699fef27a0e6cbe9c37f4c4de2fb6996a1c7/mmcv/runner/hooks/lr_updater.py#L269).

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
