### PR TITLE
Accessing custom hook type changed to dict.get()

### DIFF
--- a/mmselfsup/apis/train.py
+++ b/mmselfsup/apis/train.py
@@ -170,7 +170,7 @@ def train_model(model,
             assert isinstance(hook_cfg, dict), \
                 'Each item in custom_hooks expects dict type, but got ' \
                 f'{type(hook_cfg)}'
-            if hook_cfg.type == 'DeepClusterHook':
+            if hook_cfg.get('type', None) == 'DeepClusterHook':
                 common_params = dict(dist_mode=True, data_loaders=data_loaders)
             else:
                 common_params = dict()

--- a/tools/test.py
+++ b/tools/test.py
@@ -88,6 +88,8 @@ def main():
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))
+    # dump config
+    cfg.dump(osp.join(cfg.work_dir, osp.basename(args.config)))
 
     # logger
     timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())

--- a/tools/train.py
+++ b/tools/train.py
@@ -143,6 +143,8 @@ def main():
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))
+    # dump config
+    cfg.dump(osp.join(cfg.work_dir, osp.basename(args.config)))
 
     # init the logger before other steps
     timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())


### PR DESCRIPTION
Since hook_cfg is a dictionary, its 'type' member can not be accessed with the current dot notation (hook_cfg.type), rather it has to be accessed either with hook_cfg['type'], but that would assume the 'type' key exists, so a better alternative is to access it with hook_cfg.get('type', None). Fixes #396 

## Motivation
Adding custom hooks is not possible currently, since their type is checked with `hook_cfg.type` instead of `hook_cfg.get('type, None)`. This raises an error, since dot notation does not work for accessing values of dictionaries.

## Modification
`hook_cfg.type` changed to `hook_cfg.get('type, None)`.

## BC-breaking (Optional)
Shouldn't break backward-compatibility.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
