### PR TITLE
Dump training config similar to mmdet.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -143,6 +143,9 @@ def main():
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))
+    
+    # dump config
+    cfg.dump(osp.join(cfg.work_dir, osp.basename(args.config)))
 
     # init the logger before other steps
     timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())


### PR DESCRIPTION
## Motivation

Dump training config similar to mmdet. Fixes #400 

## Modification

Training config is dumped similar to mmdet after creating workdir.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
