### PR TITLE
DenseCL init weights copy query encoder init params to key encoder.

### DIFF
--- a/mmselfsup/models/algorithms/densecl.py
+++ b/mmselfsup/models/algorithms/densecl.py
@@ -71,6 +71,14 @@ class DenseCL(BaseModel):
         self.queue2 = nn.functional.normalize(self.queue2, dim=0)
         self.register_buffer('queue2_ptr', torch.zeros(1, dtype=torch.long))
 
+    def init_weights(self):
+        """Init weights and copy query encoder params to key encoder."""
+        super().init_weights()
+        for param_q, param_k in zip(self.encoder_q.parameters(),
+                                    self.encoder_k.parameters()):
+            param_k.data.copy_(param_q.data)
+            param_k.requires_grad = False
+
     @torch.no_grad()
     def _momentum_update_key_encoder(self):
         """Momentum update of the key encoder."""


### PR DESCRIPTION
## Motivation
DenseCL weight initialization is not done consistently with original repo, see https://github.com/WXinlong/DenseCL/blob/360df04ba25aca36d42e85c5a96552783568fccf/openselfsup/models/densecl.py#L36 and https://github.com/WXinlong/DenseCL/blob/360df04ba25aca36d42e85c5a96552783568fccf/openselfsup/models/densecl.py#L51-L58.

Fixes #404 

## Modification
DenseCL init includes calling `super().init_weights()` and then copying query encoder params to key encoder params.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
