### PR TITLE
Change hook_cfg type access to hook_cfg.get()

### DIFF
--- a/mmselfsup/apis/train.py
+++ b/mmselfsup/apis/train.py
@@ -170,7 +170,7 @@ def train_model(model,
             assert isinstance(hook_cfg, dict), \
                 'Each item in custom_hooks expects dict type, but got ' \
                 f'{type(hook_cfg)}'
-            if hook_cfg.type == 'DeepClusterHook':
+            if hook_cfg.get('type', None) == 'DeepClusterHook':
                 common_params = dict(dist_mode=True, data_loaders=data_loaders)
             else:
                 common_params = dict()


### PR DESCRIPTION
## Motivation

Python dictionary does not support dot notation to access values. Fixes #396 

## Modification

Changed `hook_cfg.type` to `hook_cfg.get('type', None)`.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
