### PR TITLE
DenseCL init weights copy query encoder weights to key encoder.

### DIFF
--- a/mmselfsup/models/algorithms/densecl.py
+++ b/mmselfsup/models/algorithms/densecl.py
@@ -49,11 +49,6 @@ class DenseCL(BaseModel):
         self.encoder_k = nn.Sequential(
             build_backbone(backbone), build_neck(neck))
 
-        for param_q, param_k in zip(self.encoder_q.parameters(),
-                                    self.encoder_k.parameters()):
-            param_k.data.copy_(param_q.data)
-            param_k.requires_grad = False
-
         self.backbone = self.encoder_q[0]
         assert head is not None
         self.head = build_head(head)
@@ -70,6 +65,14 @@ class DenseCL(BaseModel):
         self.register_buffer('queue2', torch.randn(feat_dim, queue_len))
         self.queue2 = nn.functional.normalize(self.queue2, dim=0)
         self.register_buffer('queue2_ptr', torch.zeros(1, dtype=torch.long))
+
+    def init_weights(self):
+        """Init weights and copy query encoder init weights to key encoder."""
+        super().init_weights()
+        for param_q, param_k in zip(self.encoder_q.parameters(),
+                                    self.encoder_k.parameters()):
+            param_k.data.copy_(param_q.data)
+            param_k.requires_grad = False
 
     @torch.no_grad()
     def _momentum_update_key_encoder(self):

--- a/mmselfsup/models/algorithms/densecl.py
+++ b/mmselfsup/models/algorithms/densecl.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 import torch.nn as nn
+from mmcv.utils.logging import logger_initialized, print_log
 
 from mmselfsup.utils import (batch_shuffle_ddp, batch_unshuffle_ddp,
                              concat_all_gather)
@@ -69,6 +70,17 @@ class DenseCL(BaseModel):
     def init_weights(self):
         """Init weights and copy query encoder init weights to key encoder."""
         super().init_weights()
+
+        # Get the initialized logger, if not exist,
+        # create a logger named `mmselfsup`
+        logger_names = list(logger_initialized.keys())
+        logger_name = logger_names[0] if logger_names else 'mmselfsup'
+
+        # log that key encoder is initialized by the query encoder
+        print_log(
+            'Key encoder is initialized by the query encoder.',
+            logger=logger_name)
+
         for param_q, param_k in zip(self.encoder_q.parameters(),
                                     self.encoder_k.parameters()):
             param_k.data.copy_(param_q.data)

--- a/tests/test_models/test_algorithms/test_densecl.py
+++ b/tests/test_models/test_algorithms/test_densecl.py
@@ -57,6 +57,12 @@ def test_densecl():
     assert alg.queue.size() == torch.Size([feat_dim, queue_len])
     assert alg.queue2.size() == torch.Size([feat_dim, queue_len])
 
+    alg.init_weights()
+    for param_q, param_k in zip(alg.encoder_q.parameters(),
+                                alg.encoder_k.parameters()):
+        assert torch.equal(param_q, param_k)
+        assert param_k.requires_grad is False
+
     fake_input = torch.randn((2, 3, 224, 224))
     with pytest.raises(AssertionError):
         fake_out = alg.forward_train(fake_input)


### PR DESCRIPTION
## Motivation

DenseCL weight initialization is not done consistently with original repo, when loading ImageNet pre-trained weights to backbone, it will only get loaded to the query encoder, and not the key encoder, see original repo: https://github.com/WXinlong/DenseCL/blob/360df04ba25aca36d42e85c5a96552783568fccf/openselfsup/models/densecl.py#L36 and https://github.com/WXinlong/DenseCL/blob/360df04ba25aca36d42e85c5a96552783568fccf/openselfsup/models/densecl.py#L51-L58.

Fixes #404 

## Modification

DenseCL init includes calling super().init_weights() and then copying query encoder params to key encoder params.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
