### PR TITLE
[Fix] tools/train.py does not use --gpu-id.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -41,7 +41,6 @@ def parse_args():
     group_gpus.add_argument(
         '--gpus',
         type=int,
-        default=1,
         help='(Deprecated, please use --gpu-id) number of gpus to use '
         '(only applicable to non-distributed training)')
     group_gpus.add_argument(


### PR DESCRIPTION
I can set '--gpu_id' for tools/train.py,  but it is ignored.
So I want to fix this issue by removing the default value of '--gpus'.

## Motivation

'--gpus' is deprecated, so we should use '--gpu_id'.

## Modification

Remove default value from '--gpus'.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
