### PR TITLE
[Fix] BaseDataSource.get_img() can not use 'img_info' without 'img_prefix'

### DIFF
--- a/mmselfsup/datasets/data_sources/base.py
+++ b/mmselfsup/datasets/data_sources/base.py
@@ -95,8 +95,8 @@ class BaseDataSource(object, metaclass=ABCMeta):
                 img_bytes,
                 flag=self.color_type,
                 channel_order=self.channel_order)
-        elif self.data_infos[idx].get('img_prefix', None) is not None:
-            if self.data_infos[idx]['img_prefix'] is not None:
+        elif self.data_infos[idx].get('img_info', None) is not None:
+            if self.data_infos[idx].get('img_prefix', None) is not None:
                 filename = osp.join(
                     self.data_infos[idx]['img_prefix'],
                     self.data_infos[idx]['img_info']['filename'])


### PR DESCRIPTION
As far as I can see the code, 'img_info' can be used without 'img_prefix', but it doesn't work because of a mistake in the if statement.

## Motivation

I want to use images in multiple folders.

## Modification

Fix if statement condition.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
