### PR TITLE
Change sklearn to scikit-learn in requirements

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,9 +4,9 @@ matplotlib
 mmcls
 numpy
 packaging
+scikit-learn
 scipy
 six
-sklearn
 tensorboard
 timm
 tqdm


### PR DESCRIPTION
## Motivation

The correct package name for scikit-learn is `scikit-learn`, not `sklearn` (see the [sklearn entry](https://pypi.org/project/sklearn/) on PyPI).

## Modification

This PR changes the `sklearn` requirement to `scikit-learn`.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
