### PR TITLE
T-SNE TypeError: 'int' object is not iterable bug fix

### DIFF
--- a/configs/tsne/resnet50_imagenet.py
+++ b/configs/tsne/resnet50_imagenet.py
@@ -14,7 +14,7 @@ model = dict(
         depth=50,
         in_channels=3,
         num_stages=4,
-        out_indices=(3),
+        out_indices=(3,),
         norm_cfg=dict(type='BN'),
         frozen_stages=-1),
     neck=dict(type='GlobalAveragePooling'),

--- a/configs/tsne/resnet50_imagenet.py
+++ b/configs/tsne/resnet50_imagenet.py
@@ -14,7 +14,7 @@ model = dict(
         depth=50,
         in_channels=3,
         num_stages=4,
-        out_indices=(3,),
+        out_indices=(3, ),
         norm_cfg=dict(type='BN'),
         frozen_stages=-1),
     neck=dict(type='GlobalAveragePooling'),


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

T-SNE with resnet 50 backbone throws the error mentioned in: #696 

## Modification

Modified the int type out_indices in the config to tuple type.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
